### PR TITLE
add tabline=false as an option to not use the tabline

### DIFF
--- a/lua/unclutter/config.lua
+++ b/lua/unclutter/config.lua
@@ -1,14 +1,25 @@
 ---@class Config
-local M = {
+local defaults = {
   clean_after = 3,
+  tabline = true,
 }
 
+---@class Config
+local M = defaults
+
+---@param opts Config
 function M.set(opts)
-  if opts ~= nil then
-    if type(opts.clean_after) == "number" then
-      M.clean_after = opts.clean_after
-    end
+  opts = opts or defaults
+
+  if opts.clean_after ~= nil then
+    M.clean_after = opts.clean_after
   end
+
+  if opts.tabline ~= nil then
+    M.tabline = opts.tabline
+  end
+
+  return opts
 end
 
 return M

--- a/lua/unclutter/unclutter.lua
+++ b/lua/unclutter/unclutter.lua
@@ -13,7 +13,12 @@ M.enabled = false
 ---@param opts Config
 function M.enable(opts)
   config.set(opts)
-  tabline.enable()
+
+  if config.tabline == true then
+    tabline.enable()
+  else
+    tabline.disable()
+  end
 
   if M.enabled == false then -- don't do some stuff twice if setup() is called again
     M.setup_autocmds()

--- a/readme.md
+++ b/readme.md
@@ -116,6 +116,14 @@ unclutter.telescope { format = "cwd" } -- path/folder/file.js
 unclutter.telescope { format = "filename" } -- file.js
 ```
 
+If you want to use the telescope integration without the tabline, you can disable it:
+
+```lua
+require('unclutter').setup {
+  tabline = false,
+}
+```
+
 ## Inspiration
 
 This behavior was inspired by vscode (sorry), that won't keep your tabs open until you hit save (or double-click the tab).

--- a/readme.md
+++ b/readme.md
@@ -54,6 +54,7 @@ Here's the default configuration:
 ```lua
 require('unclutter').setup {
   clean_after = 3, -- number of tabs to start uncluttering. i.e don't hide until 4 tabs are open
+  tabline = true, -- show tabline. You can set it to false and only use the [telescope integration](#telescopenvim-integration)
 }
 ```
 


### PR DESCRIPTION
might be useful if you're only interested in the telescope integration