### PR TITLE
tabline.keep_all_buffers

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,7 +40,6 @@ jobs:
         run: |
           # We have to build the parser every single time to keep up with parser changes
           cd ~/.local/share/nvim/site/pack/vendor/start/tree-sitter-lua
-          git checkout 86f74dfb69c570f0749b241f8f5489f8f50adbea
           make dist
           cd -
 

--- a/doc/unclutter.txt
+++ b/doc/unclutter.txt
@@ -8,7 +8,7 @@ unclutter.setup({opts})                                    *unclutter.setup()*
 
 
     Parameters: ~
-        {opts} (unclutter.config)
+        {opts} (unclutter)  .config
 
 
 
@@ -252,7 +252,7 @@ config.set({opts})                                              *config.set()*
 
 
     Parameters: ~
-        {opts} (unclutter.config)
+        {opts} (unclutter)  .config
 
 
 
@@ -270,7 +270,7 @@ plugin.enable({opts})                                        *plugin.enable()*
 
 
     Parameters: ~
-        {opts} (unclutter.config)
+        {opts} (unclutter)  .config
 
 
 plugin.disable()                                            *plugin.disable()*
@@ -399,9 +399,12 @@ tabline.get_tab_label({buf})                         *tabline.get_tab_label()*
         string|nil
 
 
-tabline.list()                                                *tabline.list()*
+tabline.list({hide_current})                                  *tabline.list()*
     Get all buffers to be displayed in the tabline
 
+
+    Parameters: ~
+        {hide_current} (boolean)  ?
 
     Return: ~
         table<number, number>
@@ -427,6 +430,11 @@ tabline.next()                                                *tabline.next()*
 
 tabline.prev()                                                *tabline.prev()*
     Navigate to previous buffer
+
+
+
+tabline.keep_all_buffers()                        *tabline.keep_all_buffers()*
+    Mark all open buffers as listed
 
 
 

--- a/lua/unclutter/tabline.lua
+++ b/lua/unclutter/tabline.lua
@@ -272,4 +272,11 @@ function tabline.prev()
   end
 end
 
+--- Mark all open buffers as listed
+function tabline.keep_all_buffers()
+  for _, buf in ipairs(vim.api.nvim_list_bufs()) do
+    tabline.keep_buffer(buf)
+  end
+end
+
 return tabline

--- a/lua/unclutter/tabline_spec.lua
+++ b/lua/unclutter/tabline_spec.lua
@@ -42,6 +42,16 @@ describe("Buffer management", function()
     assert.is_true(M.is_buffer_kept(1))
   end)
 
+  it("keeps all open buffers", function()
+    vim.api.nvim_list_bufs = function()
+      return { 1, 2, 3 }
+    end
+    M.keep_all_buffers()
+    assert.is_true(M.is_buffer_kept(1))
+    assert.is_true(M.is_buffer_kept(2))
+    assert.is_true(M.is_buffer_kept(3))
+  end)
+
   it("removes a buffer", function()
     M.keep_buffer(1)
     M.remove_buffer(1)

--- a/readme.md
+++ b/readme.md
@@ -110,6 +110,7 @@ local buffer = require("unclutter.buffer")
 local plugin = require("unclutter.plugin")
 
 tabline.keep_buffer(bufnr)          -- Show buffer in tabline
+tabline.keep_all_buffers()          -- Show all open buffers in tabline
 tabline.remove_buffer(bufnr)        -- Show buffer in tabline
 tabline.toggle_buffer(bufnr)        -- Toggle buffer in tabline
 tabline.list()                      -- List tabline buffers


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new method to keep all open buffers in the tabline, enhancing buffer management.
	- Expanded documentation to clarify plugin functionality, installation, and features, including integration with `telescope.nvim`.
  
- **Bug Fixes**
	- Updated tests to ensure the new buffer management functionality works as intended.

- **Documentation**
	- Enhanced `readme.md` with clearer descriptions and usage examples, including new utility functions and customization options.
	- Updated parameter types and added new parameters in the documentation for the `unclutter` module.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->