### PR TITLE
fix: degrade BufModifiedSet autocmd gracefully when event is unavailable

### DIFF
--- a/lua/unclutter/autocmds.lua
+++ b/lua/unclutter/autocmds.lua
@@ -69,9 +69,10 @@ autocmds.on_insert_enter = function(callback)
 end
 
 ---Create an autocmd for the BufModifiedSet event.
+---Falls back silently if the event is not available (e.g., older or dev builds).
 ---@param callback function: The callback function to be executed.
 autocmds.on_buf_modified_set = function(callback)
-  vim.api.nvim_create_autocmd("BufModifiedSet", {
+  pcall(vim.api.nvim_create_autocmd, "BufModifiedSet", {
     group = augroup,
     pattern = "*",
     callback = callback,


### PR DESCRIPTION
The `BufModifiedSet` event doesn't exist in all Neovim builds (missing from some 0.13.0-dev builds, and all versions before 0.10). This wraps the autocmd creation in `pcall` so the plugin loads without errors, silently degrading — the `BufWritePost` handler already covers keeping modified buffers in the tabline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility in environments where a buffer-modified event is unavailable.
  * The feature now fails gracefully without showing errors, so the app continues to work normally in more setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->