### PR TITLE
fix(ci): update nightly Neovim asset name

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            url: https://github.com/neovim/neovim/releases/download/nightly/nvim-linux64.tar.gz
+            url: https://github.com/neovim/neovim/releases/download/nightly/nvim-linux-x86_64.tar.gz
     steps:
       - uses: actions/checkout@v3
       - run: date +%F > todays-date

--- a/.github/workflows/lazy.yml
+++ b/.github/workflows/lazy.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            rev: nightly/nvim-linux64.tar.gz
+            rev: nightly/nvim-linux-x86_64.tar.gz
           - os: ubuntu-latest
             rev: v0.9.0/nvim-linux64.tar.gz
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            rev: nightly/nvim-linux64.tar.gz
+            rev: nightly/nvim-linux-x86_64.tar.gz
           - os: ubuntu-latest
             rev: v0.9.0/nvim-linux64.tar.gz
     steps:

--- a/doc/unclutter.txt
+++ b/doc/unclutter.txt
@@ -71,7 +71,8 @@ autocmds.on_insert_enter({callback})              *autocmds.on_insert_enter()*
 
 
 autocmds.on_buf_modified_set({callback})      *autocmds.on_buf_modified_set()*
-    Create an autocmd for the BufModifiedSet event.
+    Create an autocmd for the BufModifiedSet event. Falls back silently if the
+    event is not available (e.g., older or dev builds).
 
 
     Parameters: ~


### PR DESCRIPTION
## Summary

The nightly Neovim release renamed the Linux x86_64 asset from nvim-linux64.tar.gz to nvim-linux-x86_64.tar.gz, causing all CI workflows to fail with HTTP 404.

## Fix

Updated asset name in all 3 CI workflows: test.yml, lazy.yml, docs.yml. v0.9.0 still uses old naming and works fine.

*Prepared with the help of Codex (AI).*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified help text for an autocmd fallback when a buffer-modified event is unavailable in older or development builds.
* **Chores**
  * Updated nightly Linux download references in documentation, lazy-loading, and CI workflows to use the newer Neovim archive format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->