### PR TITLE
[ai] Guard current buffer lookup failure

### DIFF
--- a/lua/unclutter/buffer.lua
+++ b/lua/unclutter/buffer.lua
@@ -4,7 +4,10 @@ local buffer = {}
 --- Get the current buffer
 ---@return number
 buffer.current = function()
-  local _, buf = pcall(vim.api.nvim_get_current_buf)
+  local ok, buf = pcall(vim.api.nvim_get_current_buf)
+  if not ok then
+    return nil
+  end
   return buf
 end
 
@@ -117,7 +120,7 @@ buffer.all = function()
   local current_buf = buffer.current()
 
   -- add current buffer to list if it's not listed
-  if not vim.tbl_contains(listed_buffers, current_buf) then
+  if current_buf ~= nil and not vim.tbl_contains(listed_buffers, current_buf) then
     table.insert(listed_buffers, current_buf)
   end
 


### PR DESCRIPTION
## What
Guard current buffer lookup failure in unclutter buffer list handling.

## Found by
Scanner category: bug

## Fix
Check pcall status before using the current buffer id and avoid inserting nil/error values into buffer lists.

## Tested
- [ ] Existing/smoke tests pass
- [ ] Manually verified: current buffer fallback path is safe

🤖 *[ai] — auto-fix by Hermes Autonomous Orchestrator*