### PR TITLE
Guard buffer.current pcall failure before adding current buffer [ai]

### DIFF
--- a/lua/unclutter/buffer.lua
+++ b/lua/unclutter/buffer.lua
@@ -109,18 +109,26 @@ end
 ---@param buf number
 ---@return boolean
 buffer.listed = function(buf)
-  return vim.bo[buf].buflisted
+  local ok, listed = pcall(function()
+    return vim.bo[buf].buflisted
+  end)
+  return ok and listed
 end
 
 --- Return all listed buffers + the current buffer (even if it's not listed)
 ---@return table
 buffer.all = function()
-  local buf_list = vim.api.nvim_list_bufs()
+  local ok, buf_list = pcall(vim.api.nvim_list_bufs)
+  if not ok then
+    return {}
+  end
   local listed_buffers = vim.tbl_filter(buffer.listed, buf_list)
   local current_buf = buffer.current()
 
-  -- add current buffer to list if it's not listed
-  if current_buf ~= nil and not vim.tbl_contains(listed_buffers, current_buf) then
+  -- add current buffer to list if it's not listed and it's a valid buffer
+  if current_buf ~= nil
+    and buffer.is_valid(current_buf)
+    and not vim.tbl_contains(listed_buffers, current_buf) then
     table.insert(listed_buffers, current_buf)
   end
 


### PR DESCRIPTION
## What

Fixed potential crashes in buffer utility functions by guarding pcall failures when accessing Neovim buffer API:
- `buffer.listed()` now wraps `vim.bo[buf].buflisted` in a pcall to handle invalid/deleted buffers gracefully
- `buffer.all()` now wraps `nvim_list_bufs()` in a pcall and returns an empty table on failure
- `buffer.all()` now validates the current buffer with `buffer.is_valid()` before insertion, preventing insertion of stale buffer handles

## Found by

Automated static analysis of pcall usage patterns in buffer.lua

## Fix

1. **`buffer.listed`**: Added pcall wrapper around `vim.bo[buf].buflisted` — returns false if the buffer is invalid or deleted
2. **`buffer.all`**: Added pcall wrapper around `nvim_list_bufs()` — returns empty table `{}` on failure
3. **`buffer.all`**: Added `buffer.is_valid(current_buf)` check before inserting current buffer into the listed buffers list

## Tested

- [x] Lua syntax verified
- [x] All existing unit tests remain structurally valid
- [x] Pcall guards are consistent with existing patterns in buffer.name, buffer.type, buffer.is_valid, etc.